### PR TITLE
refactor-button组件增加是否防抖参数和radio组件兼容2.6版本一下的label

### DIFF
--- a/docs/components/TButton/base.md
+++ b/docs/components/TButton/base.md
@@ -12,6 +12,12 @@ TButton/base
 TButton/tip
 :::
 
+### 是否需要防抖
+
+:::demo 通过设置  `isDebounce` ，可以选择是否开启防抖，默认为true
+TButton/isDebounce
+:::
+
 ### 2、配置参数（Attributes）继承 el-button Attributes
 
 | 参数      | 说明                                                         | 类型                                                 | 默认值 |
@@ -22,6 +28,7 @@ TButton/tip
 | round     | 是否圆角按钮                                                 | boolean                                              | false  |
 | circle    | 是否圆形按钮                                                 | boolean                                              | false  |
 | time      | 防抖的时间                                                   | number                                               | 1000   |
+| isDebounce| 是否开启防抖                                                   | boolean                                               | true   |
 | tip       | 提示文字，常用于 type="text" 或拥有 text，link 属性的 button | string                                               | -      |
 | placement | Tooltip 组件出现的位置                                       | 继承 el-tooltip                                      | top    |
 | tipProps  | Tooltip 组件的配置参数，详情可看 element-plus 官网           | object                                               | -      |

--- a/docs/examples/TButton/isDebounce.vue
+++ b/docs/examples/TButton/isDebounce.vue
@@ -1,6 +1,12 @@
 <template>
   <t-layout-page class="t_button_demo">
     <t-layout-page-item>
+      <el-switch
+        v-model="isDebounce"
+        size="large"
+        active-text="开启防抖"
+        inactive-text="关闭防抖"
+      />
       <div style="display: flex; align-items: center">
         <div style="width: 140px; font-weight: 700">输入防抖时间：</div>
         <el-input-number
@@ -13,8 +19,13 @@
           @change="handleChange"
         />
       </div>
-      <t-button style="margin-top: 15px" color="#626aef" :time="time" @click="exportExcel"
-        >导出</t-button
+      <t-button
+        style="margin-top: 15px"
+        :isDebounce="isDebounce"
+        :time="time"
+        type="primary"
+        @click="exportExcel"
+        >点击事件</t-button
       >
     </t-layout-page-item>
   </t-layout-page>
@@ -23,6 +34,7 @@
 import { ElMessage } from "element-plus"
 import { ref } from "vue"
 const time = ref(1000)
+const isDebounce = ref(false)
 const handleChange = val => {
   console.log("输入框的值：", val)
 }

--- a/packages/button/src/index.vue
+++ b/packages/button/src/index.vue
@@ -27,17 +27,22 @@ const props = defineProps({
   tipProps: {
     type: Object,
     default: () => ({})
+  },
+  isDebounce: {
+    type: Boolean,
+    default: true
   }
 })
 // 抛出事件
 const emits = defineEmits(["click"])
 const record = ref(0)
 const handleClick = () => {
-  let newTime = new Date()
+  if (!props.isDebounce) return emits("click")
+  const newTime = new Date()
   if (newTime.getTime() - record.value > props.time) {
     emits("click")
   }
-  record.value = new Date().getTime()
+  record.value = newTime.getTime()
 }
 </script>
 <style lang="scss" scoped>

--- a/packages/radio/src/index.vue
+++ b/packages/radio/src/index.vue
@@ -7,6 +7,7 @@
         :is="radioType"
         :key="index"
         :value="item[optionsProps.value]"
+        :label="item[optionsProps.value]"
         :border="border"
         :disabled="item[optionsProps.disabled]"
       >
@@ -22,6 +23,8 @@
 import { computed, ref } from "vue"
 import type { PropType } from "vue"
 import type { OptionsProps } from "./radio"
+
+// 定义组件属性，包括类型、默认值和校验规则
 const radioProps = defineProps({
   type: {
     type: String as PropType<"radio" | "button">,
@@ -46,6 +49,8 @@ const radioProps = defineProps({
     default: () => ({})
   }
 })
+
+// 根据type属性计算出应使用的radio组件类型
 const radioType = computed(() => {
   const obj = {
     radio: "el-radio",
@@ -53,6 +58,8 @@ const radioType = computed(() => {
   }
   return obj[radioProps.type] ?? "el-radio"
 })
+
+// 合并默认的选项属性和用户自定义的属性
 const optionsProps = ref<OptionsProps>({
   ...{
     value: "value",


### PR DESCRIPTION
1、refactor-button组件增加是否防抖参数
2、button组件，优化，少创建一个new Date() 实例
3、radio组件兼容2.6版本以下的label属性
![image](https://github.com/user-attachments/assets/7687d9d2-4a41-48df-9a2a-a6cb840f1a6d)
